### PR TITLE
Fix/Certbot Install Method Detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ name: CI
   push:
     paths-ignore:
       - 'README.md'
-    branches:
-      - main
   schedule:
     - cron: "16 3 * * 0"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 
     - name: "Set detected Certbot installation method"
       ansible.builtin.set_fact:
-        certbot_netcup_installed_by: "{{ 'snap' if snap_install_check_result.rc is defined and snap_install_check_result.rc == 0 else 'other' }}"
+        certbot_netcup_installed_by: "{{ 'snap' if certbot_snap_check.rc is defined and certbot_snap_check.rc == 0 else 'other' }}"
       when:
         - certbot_install_check_result.rc is defined
         - certbot_install_check_result.rc == 0


### PR DESCRIPTION
Install method detection failed if `snap` was installed but `certbot` was not installed with `snap`