### PR TITLE
feature: Added apply_deploy_hook flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ certbot_netcup_certs: []
   #   post_hook_additional_content: ""
   #   deploy_hook_additional_content: |
   #     postfix reload
+  #   apply_deploy_hook: false
+  #   ignore_deploy_hook_errors: true
   # - domains:
   #     - example2.com
 ```
@@ -112,6 +114,9 @@ One certificate file will be created per entry in `certbot_netcup_certs`.
 `services` is a list of services to stop before certificate renewal and start again after. From these services a shell script as `pre` and `post` hook is created.
 
 `pre_hook_additional_content`, `post_hook_additional_content`, `deploy_hook_additional_content` are strings that represent additional content to be written to the corresponding hook shell scripts. This gives the flexibility to perform tasks other than starting or stopping services. The example above reloads the Postfix configfuration to refresh TLS certificates after renewal without Postfix downtime.
+
+`apply_deploy_hook` makes the role run the deploy hook if the certificate already exists. That way, an updated deploy hook (e.g. to copy the certificate to an additional, new location) can be applied as a prerequisite of installing additional software using that already-existing certificate.  
+By default, errors during execution of the deploy hook are ignored. This can be controlled by the paramter `ignore_deploy_hook_errors`.
 
 ```yaml
 certbot_cloudflare_acme_server: "{{ certbot_cloudflare_acme_test }}"

--- a/tasks/create-cert.yml
+++ b/tasks/create-cert.yml
@@ -86,3 +86,21 @@
   ansible.builtin.command: "{{ certbot_create_command }}"
   when: not letsencrypt_cert.stat.exists
   changed_when: false
+
+- name: "Run deploy hook if certificate already exists"
+  ansible.builtin.shell: >
+    RENEWED_LINEAGE=/etc/letsencrypt/live/{{ first_domain }}
+    RENEWED_DOMAINS="{{ cert_item.domains | join(' ') }}"
+    /etc/letsencrypt/domain-renewal-hooks/{{ first_domain }}/deploy_hook.sh
+  when:
+    - certbot_netcup_domain_deploy_hook_additional_content is defined
+    - certbot_netcup_domain_deploy_hook_additional_content | length > 0
+    - cert_item.apply_deploy_hook is defined
+    - cert_item.apply_deploy_hook
+    - letsencrypt_cert.stat.exists
+  changed_when: false
+  register: deploy_hook_result
+  failed_when:
+    - deploy_hook_result.rc != 0
+    - cert_item.ignore_deploy_hook_errors is defined
+    - not cert_item.ignore_deploy_hook_errors


### PR DESCRIPTION
Added a flag per certificate `apply_deploy_hook` to make the role execute the deploy hook in case the certificate already exists.
Also added flag `ignore_deploy_hook_errors` to ignore errors when running the deploy hook.

```yaml
# List of certificates to create. Each entry in the dictionary will result in a separate certificate
# based on the first domain in the list. For each domain a separate admin address may be specified. If
# none is specified, certbot_netcup_admin_email is used.
certbot_netcup_certs: []
# - domains:
#     - local.example.com
#     - *.local.example.com
#   email: admin@example.com
#   services:
#     - nginx
#   pre_hook_additional_content: ""
#   post_hook_additional_content: ""
#   deploy_hook_additional_content: |
#     postfix reload
# - domains:
#     - example2.com
```