### PR TITLE
Fix: Github Workflows with Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker] --upgrade
+        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Install ansible test dependencies
         run: ansible-galaxy install -r molecule/test_requirements.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-core>=2.20.0 molecule molecule-plugins[docker]
+        run: pip3 install ansible ansible-core>=2.20.0 molecule molecule-plugins[docker] --upgrade
 
       - name: Install ansible test dependencies
         run: ansible-galaxy install -r molecule/test_requirements.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible>=2.20.0 molecule molecule-plugins[docker]
+        run: pip3 install ansible ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Install ansible test dependencies
         run: ansible-galaxy install -r molecule/test_requirements.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-core>=2.20.0 molecule molecule-plugins[docker] --upgrade
+        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker] --upgrade
 
       - name: Install ansible test dependencies
         run: ansible-galaxy install -r molecule/test_requirements.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker]
+        run: pip3 install ansible>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Install ansible test dependencies
         run: ansible-galaxy install -r molecule/test_requirements.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.x14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker]
+        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Install ansible test dependencies
         run: ansible-galaxy install -r molecule/test_requirements.yml


### PR DESCRIPTION
- Explicitly require Python 3.14 for Github Runners
- Install `ansible-core` version >= 2.20.0 as required by Python 3.14 to Github Runners
